### PR TITLE
Update requirements to latest (printouts in debug)

### DIFF
--- a/custom_components/google_fit/manifest.json
+++ b/custom_components/google_fit/manifest.json
@@ -2,7 +2,7 @@
   "domain": "google_fit",
   "name": "Google Fit",
   "dependencies": [],
-  "version": "1.1.7",
+  "version": "1.1.8",
   "codeowners": ["@vmanuel"],
   "requirements": ["google-api-python-client==1.12.10","oauth2client==4.1.3","httplib2"]
 }

--- a/custom_components/google_fit/manifest.json
+++ b/custom_components/google_fit/manifest.json
@@ -4,5 +4,5 @@
   "dependencies": [],
   "version": "1.1.7",
   "codeowners": ["@vmanuel"],
-  "requirements": ["google-api-python-client==1.6.4","oauth2client==4.0.0","httplib2"]
+  "requirements": ["google-api-python-client==1.12.10","oauth2client==4.1.3","httplib2"]
 }


### PR DESCRIPTION
Update dependencies to latest to move printouts like:
```
[googleapiclient.discovery] URL being requested: GET https://www.googleapis.com/discovery/v1/apis/calendar/v3/rest
```

to debug